### PR TITLE
RPC: type context

### DIFF
--- a/src/server/server.sml
+++ b/src/server/server.sml
@@ -12,9 +12,30 @@ structure Server: SERVER = struct
 
 fun makeTSDescription {name=name, typeSystem=_, principalTypes=principalTypes} = (name, principalTypes);
 
-(* They're the same, but the type system can't quite manage it... *)
 fun getSpace spaces name = List.find (fn space => (#name space) = name) spaces;
-fun getPrincipalTypes systems name = List.find (fn (sname, ptyps) => sname = name) systems;
+
+fun getPrincipalTypes systems name =
+    Option.map #principalTypes
+               (List.find (fn {name=sname, principalTypes=_, ...} => sname = name) systems);
+
+fun getTypeContext systems name typ =
+    let fun makeEdges (Type.Ref _) = []
+          | makeEdges (Type.Leaf _) = []
+          | makeEdges (Type.Node (t, cs)) =
+            let val cs = FiniteSet.listOf cs;
+                fun mkedge (Type.Ref u) = [(t, u)]
+                  | mkedge (Type.Leaf u) = [(t, u)]
+                  | mkedge (Type.Node (u, cs')) = (t, u)::(List.flatmap makeEdges cs');
+            in List.flatmap mkedge cs end;
+        val system = List.find (fn {name=sname, ...} => sname = name) systems;
+        val above = Option.map (fn s => Type.superTypeDAG s typ) system;
+        val below = Option.map (fn s => Type.subTypeDAG s typ) system;
+        val edgesAbove = Option.map makeEdges above;
+        val edgesBelow = Option.map ((map flip) o makeEdges) below;
+    in case (edgesAbove, edgesBelow) of
+           (SOME a, SOME b) => List.revAppend (a, b)
+         | _ =>  []
+    end;
 
 val spaces_sig = ("server.spaces", unit_rpc, List.list_rpc(CSpace.conSpecData_rpc));
 val getSpace_sig = ("server.getSpace", String.string_rpc, Option.option_rpc(CSpace.conSpecData_rpc));
@@ -23,18 +44,22 @@ val typeSystems_sig = ("server.typeSystems",
                        List.list_rpc(Rpc.Datatype.tuple2(String.string_rpc, FiniteSet.set_rpc(Type.principalType_rpc))));
 val getPrincipalTypes_sig = ("server.getPrincipalTypes",
                              String.string_rpc,
-                             Option.option_rpc(FiniteSet.set_rpc(Type.principalType_rpc)))
+                             Option.option_rpc(FiniteSet.set_rpc(Type.principalType_rpc)));
+val getTypeContext_sig = ("server.getTypeContext",
+                          Rpc.Datatype.tuple2 (String.string_rpc, Type.typ_rpc),
+                          List.list_rpc (Rpc.Datatype.tuple2 (Type.typ_rpc, Type.typ_rpc)));
 
 fun make files =
     let
         val docs = List.map Document.read files;
         val spaces = List.flatmap Document.conSpecsDataOf docs;
-        val typeSystems = List.flatmap ((List.map makeTSDescription) o Document.typeSystemsDataOf) docs;
+        val typeSystems = List.flatmap Document.typeSystemsDataOf docs;
     in [
         Rpc.provide spaces_sig (fn () => spaces),
         Rpc.provide getSpace_sig (fn name => getSpace spaces name),
-        Rpc.provide typeSystems_sig (fn () => typeSystems),
-        Rpc.provide getPrincipalTypes_sig (fn name => Option.map #2 (getPrincipalTypes typeSystems name)),
+        Rpc.provide typeSystems_sig (fn () => map makeTSDescription typeSystems),
+        Rpc.provide getPrincipalTypes_sig (fn name => getPrincipalTypes typeSystems name),
+        Rpc.provide getTypeContext_sig (fn (systemName, typ) => getTypeContext typeSystems systemName typ),
         Construction.R.toString
     ] end;
 


### PR DESCRIPTION
Adds a new RPC endpoint to request the 'type context'  of a given type within a stated type system. The type context is the partial order that has been 'pinched' at the specified type: it retains all the super type and subtype relations for the given type. This is encoded as a list of pairs that point from the subtype to the super type.