### PR TITLE
added data for the space where transfer and inference schemas live

### DIFF
--- a/src/core/interCSpace.sml
+++ b/src/core/interCSpace.sml
@@ -4,19 +4,23 @@ import "core.relation";
 signature INTERCSPACE =
 sig
   type interConSpec = {source : CSpace.conSpecData, target : CSpace.conSpecData, inter : CSpace.conSpecData}
-  type tSchema = {name : string,
-                  source : Pattern.construction,
+  type tSchema = {source : Pattern.construction,
                   target : Pattern.construction,
                   antecedent : Pattern.construction list,
                   consequent : Pattern.construction};
+  type tSchemaData = {name : string,
+                      sourceConSpecN : string,
+                      targetConSpecN : string,
+                      interConSpecN : string,
+                      tSchema : tSchema}
+
 
   val tSchema_rpc : tSchema Rpc.Datatype.t;
 
   val wellFormedTransferSchema : interConSpec -> tSchema -> bool;
-  val nameOf : tSchema -> string;
+  val nameOf : tSchemaData -> string;
 
-  val declareTransferSchema : {name : string,
-                               source : Pattern.construction,
+  val declareTransferSchema : {source : Pattern.construction,
                                target : Pattern.construction,
                                antecedent : Pattern.construction list,
                                consequent : Pattern.construction} -> tSchema;
@@ -25,33 +29,34 @@ end;
 structure InterCSpace : INTERCSPACE =
 struct
   type interConSpec = {source : CSpace.conSpecData, target : CSpace.conSpecData, inter : CSpace.conSpecData}
-  type tSchema = {name : string,
-                   source : Pattern.construction,
+  type tSchema = {source : Pattern.construction,
                    target : Pattern.construction,
                    antecedent : Pattern.construction list,
                    consequent : Pattern.construction};
+  type tSchemaData = {name : string,
+                       sourceConSpecN : string,
+                       targetConSpecN : string,
+                       interConSpecN : string,
+                       tSchema : tSchema}
 
   val tSchema_rpc = Rpc.Datatype.convert
-                     "TransferSchemma.tSchema"
-                     (Rpc.Datatype.tuple5
-                          (String.string_rpc,
-                           Pattern.construction_rpc,
+                     "TransferSchema.tSchema"
+                     (Rpc.Datatype.tuple4
+                          (Pattern.construction_rpc,
                            Pattern.construction_rpc,
                            List.list_rpc Pattern.construction_rpc,
                            Pattern.construction_rpc))
-                     (fn (n, s, t, rs, r) => {name = n,
-                                              source = s,
+                     (fn (s, t, rs, r) => {source = s,
                                               target = t,
                                               antecedent = rs,
                                               consequent = r})
-                     (fn {name = n,
-                          source = s,
+                     (fn {source = s,
                           target = t,
                           antecedent = rs,
-                          consequent = r} => (n, s, t, rs, r));
+                          consequent = r} => (s, t, rs, r));
 
   exception badForm
-  fun wellFormedTransferSchema iCS {name,source,target,antecedent,consequent} =
+  fun wellFormedTransferSchema iCS {source,target,antecedent,consequent} =
     Pattern.wellFormed (#source iCS) source andalso Pattern.wellFormed (#target iCS) target andalso
     Pattern.wellFormed (#inter iCS) consequent andalso List.all (Pattern.wellFormed (#inter iCS)) antecedent
 

--- a/src/core/interCSpace.sml
+++ b/src/core/interCSpace.sml
@@ -16,6 +16,7 @@ sig
 
 
   val tSchema_rpc : tSchema Rpc.Datatype.t;
+  val tSchemaData_rpc: tSchemaData Rpc.Datatype.t;
 
   val wellFormedTransferSchema : interConSpec -> tSchema -> bool;
   val nameOf : tSchemaData -> string;
@@ -34,10 +35,10 @@ struct
                    antecedent : Pattern.construction list,
                    consequent : Pattern.construction};
   type tSchemaData = {name : string,
-                       sourceConSpecN : string,
-                       targetConSpecN : string,
-                       interConSpecN : string,
-                       tSchema : tSchema}
+                      sourceConSpecN : string,
+                      targetConSpecN : string,
+                      interConSpecN : string,
+                      tSchema : tSchema}
 
   val tSchema_rpc = Rpc.Datatype.convert
                      "TransferSchema.tSchema"
@@ -54,6 +55,25 @@ struct
                           target = t,
                           antecedent = rs,
                           consequent = r} => (s, t, rs, r));
+
+  val tSchemaData_rpc = Rpc.Datatype.convert
+                            "TransferSchema.tSchemaData"
+                            (Rpc.Datatype.tuple5
+                                 (String.string_rpc,
+                                  String.string_rpc,
+                                  String.string_rpc,
+                                  String.string_rpc,
+                                  tSchema_rpc))
+                            (fn (n, s, t, i, x) => {name = n,
+                                                    sourceConSpecN = s,
+                                                    targetConSpecN = t,
+                                                    interConSpecN = i,
+                                                    tSchema = x})
+                            (fn {name = n,
+                                 sourceConSpecN = s,
+                                 targetConSpecN = t,
+                                 interConSpecN = i,
+                                 tSchema = x} => (n, s, t, i, x));
 
   exception badForm
   fun wellFormedTransferSchema iCS {source,target,antecedent,consequent} =

--- a/src/oruga/document.sml
+++ b/src/oruga/document.sml
@@ -17,7 +17,7 @@ sig
   val findTypeSystemDataWithName : documentContent -> string -> Type.typeSystemData
   val findConSpecWithName : documentContent -> string -> CSpace.conSpecData
   val findConstructionWithName : documentContent -> string -> constructionData
-  val findTransferSchemaWithName : documentContent -> string -> InterCSpace.tSchema
+  val findTransferSchemaWithName : documentContent -> string -> InterCSpace.tSchemaData
 
 end;
 
@@ -135,9 +135,7 @@ struct
        {typeSystemsData : Type.typeSystemData list,
         conSpecsData : CSpace.conSpecData list,
         knowledge : Knowledge.base,
-        constructionsData : {name : string,
-                             conSpecN : string,
-                             construction : Construction.construction} list,
+        constructionsData : constructionData list,
         transferRequests : (string list) list,
         strengths : string -> real option}
 
@@ -402,17 +400,20 @@ struct
       val _ = if Construction.wellFormed idConSpec consequent
               then Logging.write "\n  consequent pattern is well formed\n"
               else Logging.write "\n  WARNING: consequent pattern is not well formed\n"
-      val isch = {name = name,
-                  context = context,
+      val isch = {context = context,
                   antecedent = antecedent,
                   consequent = consequent}
+      val ischData = {name = name,
+                      contextConSpecN = contextConSpecN,
+                      idConSpecN = idConSpecN,
+                      iSchema = isch}
       val strengthVal = getStrength blocks
       fun strengthsUpd c = if c = name then SOME strengthVal else (#strengths dc) c
       val _ = Logging.write ("done\n");
       fun ff (c,c') = Real.compare (valOf (strengthsUpd (#name c')), valOf (strengthsUpd (#name c)))
   in {typeSystemsData = #typeSystemsData dc,
       conSpecsData = #conSpecsData dc,
-      knowledge = Knowledge.addInferenceSchema (#knowledge dc) isch strengthVal ff,
+      knowledge = Knowledge.addInferenceSchema (#knowledge dc) ischData strengthVal ff,
       constructionsData = #constructionsData dc,
       transferRequests = #transferRequests dc,
       strengths = strengthsUpd}
@@ -475,18 +476,22 @@ struct
       val _ = if Construction.wellFormed interConSpec consequent
               then Logging.write "\n  consequent pattern is well formed\n"
               else Logging.write "\n  WARNING: consequent pattern is not well formed\n"
-      val tsch = {name = name,
-                  source = source,
+      val tsch = {source = source,
                   target = target,
                   antecedent = antecedent,
                   consequent = consequent}
+      val tschData = {name = name,
+                      sourceConSpecN = sourceConSpecN,
+                      targetConSpecN = targetConSpecN,
+                      interConSpecN = interConSpecN,
+                      tSchema = tsch}
       val strengthVal = getStrength blocks
       fun strengthsUpd c = if c = name then SOME strengthVal else (#strengths dc) c
       val _ = Logging.write ("done\n");
       fun ff (c,c') = Real.compare (valOf (strengthsUpd (InterCSpace.nameOf c')), valOf (strengthsUpd (InterCSpace.nameOf c)))
   in {typeSystemsData = #typeSystemsData dc,
       conSpecsData = #conSpecsData dc,
-      knowledge = Knowledge.addTransferSchema (#knowledge dc) tsch strengthVal ff,
+      knowledge = Knowledge.addTransferSchema (#knowledge dc) tschData strengthVal ff,
       constructionsData = #constructionsData dc,
       transferRequests = #transferRequests dc,
       strengths = strengthsUpd}

--- a/src/transfer/structure_transfer.sml
+++ b/src/transfer/structure_transfer.sml
@@ -106,7 +106,9 @@ struct
       val instantiatedISchema = {antecedent = updatedAntecedent,
                                  consequent = updatedConsequent,
                                  context = matchingSubConstruction}
-      val instantiatedISchemaData = {name = name, contextConSpecN = contextConSpecN, idConSpecN = idConSpecN,
+      val instantiatedISchemaData = {name = name,
+                                     contextConSpecN = contextConSpecN,
+                                     idConSpecN = idConSpecN,
                                      iSchema = instantiatedISchema}
       val transferProof = State.transferProofOf st
       val updatedTransferProof = TransferProof.attachISchemaAt instantiatedISchemaData goal transferProof


### PR DESCRIPTION
I think this should work. 
Now we store data for tSchemas and iSchemas.
More importantly, applyTransfer filters the knowledge before starting so that it only applies the schemas that live in the specified interSpace.