### PR TITLE
improved document parser 

### DIFF
--- a/src/oruga/document.sml
+++ b/src/oruga/document.sml
@@ -161,12 +161,8 @@ struct
               | ("{"::xL,"}"::xL') => removeOuterJunk (xL,xL')
               | ("["::xL,"]"::xL') => removeOuterJunk (xL,xL')
               | _ => (L,L'))
-        fun splitInHalf (H,(x::L)) = if length L < length H
-                                     then (H,x::L)
-                                     else splitInHalf ((x::H),L)
-          | splitInHalf (H,[]) = (H,[])
-        val (wL1,wL2) = splitInHalf ([],wL)
-        val (wL1',wL2') = removeOuterJunk (rev wL1, rev wL2)
+        val (wL1,wL2) = List.split (wL, (List.length wL) div 2)
+        val (wL1',wL2') = removeOuterJunk (wL1, rev wL2)
     in wL1' @ rev wL2'
     end
 

--- a/src/oruga/document.sml
+++ b/src/oruga/document.sml
@@ -141,7 +141,7 @@ struct
         fun standAlone x = (x = #"(" orelse x = #")" orelse
                             x = #"[" orelse x = #"]" orelse
                             x = #"{" orelse x = #"}" orelse
-                            x = #"\"" orelse x = #",")
+                            x = #"\"" orelse x = #"," orelse x = #"=")
         fun t [] = (true,[])
           | t (x::xs) =
             if commentChar x then (true, #2(t (ignoreUntil lineBreak xs)))

--- a/src/oruga/document.sml
+++ b/src/oruga/document.sml
@@ -19,6 +19,8 @@ sig
   val findConstructionWithName : documentContent -> string -> constructionData
   val findTransferSchemaWithName : documentContent -> string -> InterCSpace.tSchemaData
 
+  val parseConstruction_rpc : (string -> CSpace.conSpecData option) -> Rpc.endpoint
+
 end;
 
 structure Document : DOCUMENT =
@@ -118,6 +120,17 @@ struct
     in Construction.fixReferences (c (String.stripSpaces s))
     end;
 
+  val parseConstruction_rpc =
+   fn findCSpec =>
+      Rpc.provide ("oruga.document.parseConstruction",
+                   Rpc.Datatype.tuple2(String.string_rpc, String.string_rpc),
+                   Option.option_rpc(Construction.construction_rpc))
+                  (fn (cspecName, s) =>
+                      Option.mapPartial
+                          (fn cspec => SOME (parseConstruction cspec s)
+                                       handle ParseError => NONE)
+                          (findCSpec cspecName) );
+                          
   fun ignoreUntil _ [] = []
     | ignoreUntil f (h::L) = if f h then L else ignoreUntil f L
 

--- a/src/oruga/document.sml
+++ b/src/oruga/document.sml
@@ -130,7 +130,7 @@ struct
                           (fn cspec => SOME (parseConstruction cspec s)
                                        handle ParseError => NONE)
                           (findCSpec cspecName) );
-                          
+
   fun ignoreUntil _ [] = []
     | ignoreUntil f (h::L) = if f h then L else ignoreUntil f L
 
@@ -799,10 +799,19 @@ struct
 
 
   fun read filename =
-  let val file = TextIO.openIn ("input/"^filename)
-      val s = TextIO.inputAll file
-      val _ = TextIO.closeIn file
-      val words = tokenise s
+  let val file_str =
+          let
+            val file = TextIO.openIn ("input/"^filename);
+            val contents = TextIO.inputAll file;
+          in
+            TextIO.closeIn file;
+            contents
+          end
+      handle IO.Io _ =>
+        (print("File NOT found: input/" ^ filename ^ "\n");
+        OS.Process.exit(OS.Process.failure));
+
+      val words = tokenise file_str
       val blocks = gatherMaterialByKeywords bigKeywords words
 
       val importFilenames = List.filter (fn (x,_) => x = SOME importKW) blocks

--- a/src/server/server.sml
+++ b/src/server/server.sml
@@ -132,7 +132,8 @@ fun make files transferMap =
         Rpc.provide transfer_sig (fn (constr, srcSpace, tgtSpace, interSpace) =>
                                      transfer constr srcSpace tgtSpace interSpace spaces knowledge),
         Construction.R.toString,
-        Construction.R.typeCheck (getSpace spaces)
+        Construction.R.typeCheck (getSpace spaces),
+        Document.parseConstruction_rpc (getSpace spaces)
     ] @ map #2 Renderers.all end;
 
 end;


### PR DESCRIPTION
it now allows line comments using hash  # this one would be ignored

The parser is also now more robust as it allows "protecion" of levels using brackets.
The idea is that we could now in principle do silly things such as naming a type "conSpec" and it would not break the parser as long as the types get protected by some brackets. 
When reading a document the parser only searches for the keywords at the current bracketing level.

example: 
typeSystem silly =
   types {one, two, construction, conSpec, types}
   order ...