### PR TITLE
Graph

### DIFF
--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -147,6 +147,8 @@ struct
   fun findReificationsUpTo T f g1 g2 tks =
     findMonomorphisms f (fn (t1,t2) => tokenSpecialises T t2 t1 orelse tokenInSet t1 tks) g1 g2
 
+  fun findLooseningsUpTo T f g1 g2 tks = Seq.map invertMap (findReificationsUpTo T f g2 g1 tks)
+
   fun findLPMonomorphismsUpTo T f g1 g2 tks = 
     findMonomorphisms f (fn (t1,t2) => equivalentTokens t1 t2 orelse tokenInSet t1 tks) g1 g2
 
@@ -157,7 +159,5 @@ struct
   (* The following actually allows extra constructor vertices to exist on g2 as long as we can inject g1 into g2 and tokens are in bijection *)
   fun findLPIsomorphismsUpTo T f g1 g2 tks = 
     Seq.filter (fn (_,f2) => isTotalOver f2 g2) (findLPMonomorphismsUpTo T f g1 g2 tks)
-
-  fun findLooseningsUpTo T f g1 g2 tks = Seq.map invertMap (findReificationsUpTo T f g2 g1 tks)
 
 end

--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -29,8 +29,8 @@ sig
   *)
   val findMonomorphisms : (token * token -> bool) -> map -> graph -> graph -> map Seq.seq;
 
-  val findReificationsUpTo : Type.typeSystem -> token list -> map -> graph -> graph -> map Seq.seq;
-  val findLooseningsUpTo : Type.typeSystem -> token list -> map -> graph -> graph -> map Seq.seq;
+  val findReificationsUpTo : Type.typeSystem -> token list * token list -> map -> graph -> graph -> map Seq.seq;
+  val findLooseningsUpTo : Type.typeSystem -> token list * token list -> map -> graph -> graph -> map Seq.seq;
 
 end
 
@@ -174,13 +174,13 @@ struct
 
   fun tokenInSet t tks = List.exists (fn x => CSpace.sameTokens t x) tks
 
-  fun findReificationsUpTo T tks f g1 g2 =
-    findMonomorphisms (fn (t1,t2) => tokenSpecialises T t2 t1 orelse tokenInSet t1 tks) f g1 g2
+  fun findReificationsUpTo T (tks1,tks2) f g1 g2 =
+    findMonomorphisms (fn (t1,t2) => tokenSpecialises T t2 t1 orelse tokenInSet t1 tks1 orelse tokenInSet t2 tks2) f g1 g2
 
-  fun findLooseningsUpTo T tks f g1 g2 = Seq.map invertMap (findReificationsUpTo T tks f g2 g1)
+  fun findLooseningsUpTo T (tks1,tks2) f g1 g2 = Seq.map invertMap (findReificationsUpTo T (tks2,tks1) f g2 g1)
 
-  fun findLPMonomorphismsUpTo T tks f g1 g2 = 
-    findMonomorphisms (fn (t1,t2) => equivalentTokens t1 t2 orelse tokenInSet t1 tks) f g1 g2
+  fun findLPMonomorphismsUpTo T (tks1,tks2) f g1 g2 = 
+    findMonomorphisms (fn (t1,t2) => equivalentTokens t1 t2 orelse tokenInSet t1 tks1 orelse tokenInSet t2 tks2) f g1 g2
 
   (* The following actually allows extra constructor vertices to exist on g2 as long as we can inject g1 into g2 and tokens are in bijection *)
   fun findLPIsomorphismsUpTo T tks f g1 g2 = 
@@ -200,8 +200,8 @@ sig
   
   val findMonomorphisms : (token * token -> bool) -> map -> mgraph -> mgraph -> map Seq.seq;
 
-  val findReificationsUpTo : Type.typeSystem -> token list -> map -> mgraph -> mgraph-> map Seq.seq;
-  val findLooseningsUpTo : Type.typeSystem -> token list -> map -> mgraph -> mgraph -> map Seq.seq;
+  val findReificationsUpTo : Type.typeSystem -> token list * token list -> map -> mgraph -> mgraph-> map Seq.seq;
+  val findLooseningsUpTo : Type.typeSystem -> token list * token list -> map -> mgraph -> mgraph -> map Seq.seq;
 end
 
 structure MGraph : MGRAPH =

--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -1,0 +1,163 @@
+import "core.cspace";
+
+(* Graphs in a multi-space *)
+signature GRAPH =
+sig 
+  type token;
+  type constructor;
+
+  type TIN; (* token's incoming neighbourhood *)
+  type graph;
+  type map;
+
+  val wellTyped : CSpace.conSpecData -> graph -> bool;
+  val wellFormed : CSpace.conSpecData -> graph -> bool;
+  val tokensOfTIN : TIN -> token list;
+  val tokensOfGraph : graph -> token list;
+
+  (*
+  val normal : graph -> bool;
+  val normalise : graph -> graph;
+  *)
+
+  (* findMonomorphisms f p g1 g2 finds every monomorphism m of g1 to g2 that satisfies p(t,m(t)) and is compatible with f *)
+  val findMonomorphisms : map -> (token * token -> bool) -> graph -> graph -> map Seq.seq;
+
+  val findReificationsUpTo : Type.typeSystem -> map -> graph -> graph -> token list -> map Seq.seq;
+  val findLooseningsUpTo : Type.typeSystem -> map -> graph -> graph -> token list -> map Seq.seq;
+
+end
+
+structure Graph:GRAPH =
+struct
+  (*type typ = Type.typ*)
+  (*type sig = {input : typ list, output : typ}*)
+  type token = CSpace.token (*{id : string, type : typ}*)
+  type constructor = CSpace.constructor (*{id : string, sig : sig}*)
+  type 'a set = 'a list
+
+  type TIN = {token : token, inputs : {constructor : string, inputTokens : token list} set}
+  type graph = TIN set
+  type map = (token -> token option) * (token -> token option)
+
+  fun invertMap (f1,f2) = (f2,f1)
+
+  exception Malformed of string;
+
+  fun tokensMatchTypes T (t::ts) (ty::tys) = 
+    (#subType T) (CSpace.typeOfToken t, ty) andalso tokensMatchTypes T ts tys
+    | tokensMatchTypes T [] [] = true
+    | tokensMatchTypes _ _ _ = raise Malformed "mismatched number of arguments"
+
+  fun wellTyped CSD [] = true
+    | wellTyped CSD (tin::g) =
+    let val TSD = #typeSystemData CSD
+        val T = #typeSystem TSD
+        val t = #token tin
+        fun checkInputs [] = true
+          | checkInputs (inp::IN) = 
+            (case CSpace.findConstructorWithName (#constructor inp) CSD of 
+                SOME c => 
+                  let val (tys,ty) = CSpace.csig c
+                      val ts = #inputTokens inp
+                  in tokensMatchTypes T (t::ts) (ty::tys) andalso checkInputs IN
+                  end 
+              | NONE => raise Malformed "unkown constructor")
+    in checkInputs (#inputs tin) andalso wellTyped CSD g
+    end
+
+  fun noDuplicatedTokens g =
+    let fun ndt _ [] = true
+          | ndt tks (tin::g') = 
+            (case CSpace.nameOfToken (#token tin) of s => 
+              not (List.exists (fn x => x = s) tks) andalso ndt (s::tks) g')
+    in ndt [] g
+    end
+
+  fun wellFormed CSD g = 
+    noDuplicatedTokens g andalso 
+    wellTyped CSD g handle Malformed _ => false 
+
+  exception Fail
+
+  fun addPair (x,y) (fl,fr) = 
+      (case fl x of 
+          SOME z => if CSpace.sameTokens y z then fl else raise Fail
+        | NONE => (fn t => if CSpace.sameTokens t x then SOME y else fl t),
+      case fr y of 
+          SOME z => if CSpace.sameTokens x z then fr else raise Fail
+        | NONE => (fn t => if CSpace.sameTokens t y then SOME x else fr t))
+
+  fun matchAllPairs f p (x::X) (y::Y) = if p(x,y) then matchAllPairs (addPair (x,y) f) p X Y else raise Fail
+    | matchAllPairs f _ [] [] = f
+    | matchAllPairs _ _ _ _ = raise Fail
+
+  fun findInputMatches f p in1 [] = Seq.empty
+    | findInputMatches f p in1 (in2::IN2') =
+      let 
+        val rest = findInputMatches f p in1 IN2'
+      in
+        if #constructor in1 = #constructor in2 then 
+          Seq.cons (matchAllPairs f p (#inputTokens in1) (#inputTokens in2), in2) rest handle Fail => rest
+        else
+          rest
+      end
+
+  fun findINMonomorphisms f p [] IN2 = Seq.single f
+    | findINMonomorphisms f p (in1::IN1') IN2 =
+      let 
+        fun MonomorphismsPerResult (f',in2) = findINMonomorphisms f' p IN1' (List.remove in2 IN2)
+        val inputMatches = findInputMatches f p in1 IN2
+      in 
+        Seq.maps MonomorphismsPerResult inputMatches
+      end
+
+  fun findTINMonomorphisms f p tin1 tin2 =
+    let 
+      val (t1,t2) = (#token tin1,#token tin2)
+    in
+      if p(t1,t2) then 
+        findINMonomorphisms (addPair (t1,t2) f) p (#inputs tin1) (#inputs tin2) handle Fail => Seq.empty
+      else
+        Seq.empty
+    end
+
+  fun findTINMatches f p tin1 [] = Seq.empty
+    | findTINMatches f p tin1 (tin2::g2') =
+        let 
+          val rest = findTINMatches f p tin1 g2'
+        in
+            Seq.cons (findTINMonomorphisms f p tin1 tin2, tin2) rest handle Fail => rest
+        end
+
+  fun findMonomorphisms f p [] g2 = Seq.single f
+    | findMonomorphisms f p (tin1::g1') g2 =
+          let 
+            fun MonomorphismsPerResult (F,tin2) = let val g2' = List.remove tin2 g2 in Seq.maps (fn f' => findMonomorphisms f' p g1' g2') F end
+            val TINMatches = findTINMatches f p tin1 g2
+          in 
+            Seq.maps MonomorphismsPerResult TINMatches
+          end
+
+  fun tokenSpecialises T t1 t2 = (#subType T) (CSpace.typeOfToken t1,CSpace.typeOfToken t2)
+  fun equivalentTokens t1 t2 = CSpace.tokensHaveSameType t1 t2
+
+  fun tokenInSet t tks = List.exists (fn x => CSpace.sameTokens t x) tks
+
+  fun findReificationsUpTo T f g1 g2 tks =
+    findMonomorphisms f (fn (t1,t2) => tokenSpecialises T t2 t1 orelse tokenInSet t1 tks) g1 g2
+
+  fun findLPMonomorphismsUpTo T f g1 g2 tks = 
+    findMonomorphisms f (fn (t1,t2) => equivalentTokens t1 t2 orelse tokenInSet t1 tks) g1 g2
+
+  fun tokensOfTIN tin = #token tin :: List.flatmap #inputTokens (#inputs tin)
+  fun tokensOfGraph g = List.flatmap tokensOfTIN g
+  fun isTotalOver f g = List.all (fn x => isSome (f x)) (tokensOfGraph g)
+
+  (* The following actually allows extra constructor vertices to exist on g2 as long as we can inject g1 into g2 and tokens are in bijection *)
+  fun findLPIsomorphismsUpTo T f g1 g2 tks = 
+    Seq.filter (fn (_,f2) => isTotalOver f2 g2) (findLPMonomorphismsUpTo T f g1 g2 tks)
+
+  fun findLooseningsUpTo T f g1 g2 tks = Seq.map invertMap (findReificationsUpTo T f g2 g1 tks)
+
+end

--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -28,7 +28,7 @@ sig
   val remove : graph -> graph -> graph;
   val normalise : graph -> graph;
 
-  val findSubgraphs : graph -> graph Seq.seq;
+  val subgraphs : graph -> graph Seq.seq;
 
   (* 
   findMonomorphisms f p g1 g2 finds every extension of f that is a monomorphism 
@@ -172,7 +172,7 @@ struct
           [] => tin :: expand g 
         | (inp::INP) => {token = #token tin, inputs = [inp]} :: (expand ({token = #token tin, inputs = INP}::g)))
 
-  fun findSubgraphs g =
+  fun subgraphs g =
     let fun fsg [] = Seq.single empty
           | fsg (tin::g') = 
           let val S = fsg g' 
@@ -342,7 +342,7 @@ sig
   val join : mgraph -> mgraph -> mgraph;
   val remove : mgraph -> mgraph -> mgraph;
 
-  val findSubgraphs : mgraph -> mgraph Seq.seq;
+  val subgraphs : mgraph -> mgraph Seq.seq;
   
   val findMonomorphisms : (token * token -> bool) -> map -> mgraph -> mgraph -> map Seq.seq;
 
@@ -395,7 +395,7 @@ struct
   fun mapProduct f [] = Seq.single []
     | mapProduct f (g::gs) = Seq.maps (fn h => (Seq.map (fn x => h :: x) (mapProduct f gs))) (f g)
 
-  fun findSubgraphs g = mapProduct Graph.findSubgraphs g
+  fun subgraphs g = mapProduct Graph.subgraphs g
  
   fun foldMaps h f [] [] = Seq.single f
     | foldMaps h f (x::X) (y::Y) = Seq.maps (fn f' => foldMaps h f' X Y) (h f x y)

--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -1,9 +1,101 @@
 import "core.cspace";
 
+signature TOKEN_MAP =
+sig
+  type token;
+  type map; (* these maps are one-to-one relations between tokens. Useful as we use monomorphisms a lot. *)
+
+  exception Fail
+  val emptyMap : map;
+  val identityMap : map;
+  val addPair : token * token -> map -> map;
+  val updatePair : token * token -> map -> map;
+  
+  val applyMap : map -> token -> token option;
+  val applyInvMap : map -> token -> token option;
+
+  val invertMap : map -> map; (* inverse *)
+  
+  val oo : map * map -> map; (* composition *)
+  val restrictDomain : map -> token list -> map; (* restriction of domain *)
+  val extendDomain : map -> token list -> string list -> map * string list; (* extention of domain *)
+end
+
+structure TokenMap : TOKEN_MAP =
+struct
+  type token = CSpace.token
+  type map = (token -> token option) * (token -> token option)
+
+  val emptyMap = (fn _ => NONE, fn _ => NONE)
+  val identityMap = (fn t => SOME t, fn t => SOME t)
+
+  infix 6 oo
+  fun (f1,f2) oo (f1',f2') = (fn t => case f1' t of SOME x => f1 x | NONE => NONE, fn t => case f2 t of SOME x => f2' x | NONE => NONE)
+ 
+  exception Fail
+  (* updates a monomorphism so that fl(x) = y and fr(y) = x. 
+     Fails if map is already defined on that pair with different value. *)
+  fun addPair (x,y) (fl,fr) = 
+      (case fl x of 
+          SOME z => if CSpace.sameTokens y z then fl else raise Fail
+        | NONE => (fn t => if CSpace.sameTokens t x then SOME y else fl t),
+       case fr y of 
+          SOME z => if CSpace.sameTokens x z then fr else raise Fail
+        | NONE => (fn t => if CSpace.sameTokens t y then SOME x else fr t))
+
+  (* updates a monomorphism so that fl(x) = y and fr(y) = x. 
+     Forces new value. *)
+  fun updatePair (x,y) (fl,fr) =
+      (fn t => if CSpace.sameTokens t x then SOME y else fl t,
+       fn t => if CSpace.sameTokens t y then SOME x else fr t)
+
+  (*
+    functions for building and operating with maps
+  *)
+  fun applyMap (f1,_) = f1
+  fun applyInvMap (_,f2) = f2
+
+  fun invertMap (f1,f2) = (f2,f1)
+  fun restrictDomain (f1,f2) tks =
+    (fn t => if List.exists (fn x => CSpace.sameTokens x t) tks then NONE else f1 t,
+     fn t => (case f2 t of NONE => NONE | SOME y => if List.exists (fn x => CSpace.sameTokens x y) tks then NONE else f2 t))
+
+  fun firstUnusedName Ns =
+    let fun mkFun n =
+          let val vcandidate = "v_{"^(Int.toString n)^"}"
+          in if List.exists (fn x => x = vcandidate) Ns
+              then mkFun (n+1)
+              else vcandidate
+          end
+    in mkFun 0
+    end
+
+  (* 
+    assuming f : g -> h is a monomorphism, it extends f to another monomorphism f', so that
+    the domain of f' contains tokensToExtend and f' preserves their labels, 
+    taking care that f(x) avoids tokens in tokenNamesToAvoid 
+  *)
+  fun extendDomain f [] tokenNamesToAvoid = (f,tokenNamesToAvoid)
+    | extendDomain f (t::tokensToExtend) tokenNamesToAvoid = 
+    let 
+      val (updatedMap,updatedTks) = 
+        case applyMap f t of 
+            SOME t' => (f, tokenNamesToAvoid)
+          | NONE => 
+              let val newTokenName = firstUnusedName tokenNamesToAvoid
+              in (addPair (t,CSpace.makeToken newTokenName (CSpace.typeOfToken t)) f, newTokenName :: tokenNamesToAvoid)
+              end
+    in 
+      extendDomain updatedMap tokensToExtend updatedTks
+    end
+
+end
+
 (* Graphs in a multi-space *)
 signature GRAPH =
 sig 
-  type token;
+  include TOKEN_MAP
+
   type constructor;
 
   type TIN; (* token's incoming neighbourhood *)
@@ -12,26 +104,18 @@ sig
     Tokens are differenciated but constructor vertices are not. This restrictrs us to token-functional graphs. *)
   type graph; 
 
-  type map; (* these maps are one-to-one relations between tokens. Useful as we use monomorphisms a lot. *)
-
-  val emptyMap : map;
-  val identityMap : map;
-  val addPair : token * token -> map -> map;
-  val updatePair : token * token -> map -> map;
-  
-  val applyMap : map -> token -> token option;
-  val applyInvMap : map -> token -> token option;
   val image : map -> graph -> graph;
   val preImage : map -> graph -> graph;
-  val extendMap : map -> token list -> string list -> map * string list;
 
   val wellTyped : CSpace.conSpecData -> graph -> bool;
   val wellFormed : CSpace.conSpecData -> graph -> bool;
   val tokenInGraphQuick : token -> graph -> bool;
   val insertTokens : token list -> token list -> token list;
+  val insertStrings : string list -> string list -> string list;
   val tokensOfGraphFull : graph -> token list;
   (* the quick version assumes the graph representation is already in normal form *)
   val tokensOfGraphQuick : graph -> token list;
+  val tokenNamesOfGraphQuick : graph -> string list;
 
   (*
   val normal : graph -> bool;
@@ -45,8 +129,8 @@ sig
   val subgraphs : graph -> graph Seq.seq;
 
   (* 
-  findMonomorphisms f p g1 g2 finds every extension of f that is a monomorphism 
-  m from g1 to g2 provided it satisfies p(t,m(t)) for every token t.
+  findMonomorphisms p f g1 g2 finds every extension of f that is a monomorphism 
+  m from g1 to g2 where p(t,m(t)) is satisfied for every token t.
   It assumes the g1 and g2 are in normal form.
   *)
   val findMonomorphisms : (token * token -> bool) -> map -> graph -> graph -> map Seq.seq;
@@ -80,10 +164,9 @@ struct
 
   type TIN = {token : token, inputs : {constructor : string, inputTokens : token list} set}
   type graph = TIN set
-  type map = (token -> token option) * (token -> token option)
-
-  val emptyMap = (fn _ => NONE, fn _ => NONE)
-  val identityMap = (fn t => SOME t, fn t => SOME t)
+  
+  open TokenMap
+  infix 6 oo
 
   exception Malformed of string;
 
@@ -172,9 +255,17 @@ struct
 
   fun insertToken t [] = [t]
     | insertToken t (t'::tks) = if CSpace.sameTokens t t' then t' :: tks else t' :: insertToken t tks
+  fun insertString x [] = [x]
+    | insertString x (y::L) = 
+      case String.compare (x,y) of 
+          LESS => y :: insertString x L
+        | EQUAL => y :: L
+        | GREATER => x :: (y::L)
   fun insertTokens tks tks' = List.foldl (fn (t,L) => insertToken t L) tks' tks
+  fun insertStrings tks tks' = List.foldl (fn (t,L) => insertString t L) tks' tks
   val tokensOfGraphFull = List.foldl (fn (tin,L) => insertTokens (#token tin :: List.maps #inputTokens (#inputs tin)) L) []
   val tokensOfGraphQuick = List.foldl (fn (tin,L) => insertToken (#token tin) L) []
+  val tokenNamesOfGraphQuick = List.foldl (fn (tin,L) => insertString (CSpace.nameOfToken (#token tin)) L) []
 
   fun normalise g = join g (makeFromTokens (tokensOfGraphFull g))
 
@@ -206,17 +297,9 @@ struct
     in Seq.map normalise (fsg (expand g))
     end
 
-  exception Fail
 
-
-  (*
-    functions for building and operating with maps
-  *)
-  fun invertMap (f1,f2) = (f2,f1)
 
   exception Undefined
-  fun applyMap (f1,_) = f1
-  fun applyInvMap (_,f2) = f2
 
   fun image (f1,_) g =
     let
@@ -233,51 +316,6 @@ struct
     end
 
   fun preImage f g = image (invertMap f) g
-
-  (* updates a monomorphism so that fl(x) = y and fr(y) = x. 
-     Fails if map is already defined on that pair with different value. *)
-  fun addPair (x,y) (fl,fr) = 
-      (case fl x of 
-          SOME z => if CSpace.sameTokens y z then fl else raise Fail
-        | NONE => (fn t => if CSpace.sameTokens t x then SOME y else fl t),
-       case fr y of 
-          SOME z => if CSpace.sameTokens x z then fr else raise Fail
-        | NONE => (fn t => if CSpace.sameTokens t y then SOME x else fr t))
-
-  (* updates a monomorphism so that fl(x) = y and fr(y) = x. 
-     Forces new value. *)
-  fun updatePair (x,y) (fl,fr) =
-      (fn t => if CSpace.sameTokens t x then SOME y else fl t,
-       fn t => if CSpace.sameTokens t y then SOME x else fr t)
-
-  fun firstUnusedName Ns =
-    let fun mkFun n =
-          let val vcandidate = "v_{"^(Int.toString n)^"}"
-          in if List.exists (fn x => x = vcandidate) Ns
-              then mkFun (n+1)
-              else vcandidate
-          end
-    in mkFun 0
-    end
-
-  (* 
-    assuming f : g -> h is a monomorphism, it extends f to another monomorphism f', so that
-    the domain of f' contains tokensToExtend and f' preserves their labels, 
-    taking care that f(x) avoids tokens in tokenNamesToAvoid 
-    *)
-  fun extendMap f [] tokenNamesToAvoid = (f,tokenNamesToAvoid)
-    | extendMap f (t::tokensToExtend) tokenNamesToAvoid = 
-    let 
-      val (updatedMap,updatedTks) = 
-        case applyMap f t of 
-            SOME t' => (f, tokenNamesToAvoid)
-          | NONE => 
-              let val newTokenName = firstUnusedName tokenNamesToAvoid
-              in (addPair (t,CSpace.makeToken newTokenName (CSpace.typeOfToken t)) f, newTokenName :: tokenNamesToAvoid)
-              end
-    in 
-      extendMap updatedMap tokensToExtend updatedTks
-    end
 
   fun matchAllPairs p f (x::X) (y::Y) = if p(x,y) then matchAllPairs p (addPair (x,y) f) X Y else raise Fail
     | matchAllPairs _ f [] [] = f
@@ -363,16 +401,13 @@ end
 
 signature MGRAPH =
 sig
+  type mTypeSystem = Type.typeSystem list
   type mgraph = Graph.graph list
-  type token
+  include TOKEN_MAP
   type constructor
-  type map
 
-  val applyMap : map -> token -> token option;  
-  val applyInvMap : map -> token -> token option;
   val image : map -> mgraph -> mgraph;
   val preImage : map -> mgraph -> mgraph;
-  val extendMap : map -> token list -> string list -> map * string list;
 
   val wellTyped : CSpace.conSpecData list -> mgraph -> bool;
   val wellFormed : CSpace.conSpecData list -> mgraph -> bool;
@@ -381,6 +416,7 @@ sig
   val empty : int -> mgraph;
   val tokensOfGraphFull : mgraph -> token list;
   val tokensOfGraphQuick : mgraph -> token list;
+  val tokenNamesOfGraphQuick : mgraph -> string list;
   
   val join : mgraph -> mgraph -> mgraph;
   val remove : mgraph -> mgraph -> mgraph;
@@ -388,28 +424,26 @@ sig
   val subgraphs : mgraph -> mgraph Seq.seq;
   val subgraphsRestricted : (int -> bool) -> mgraph -> mgraph Seq.seq;
   
-  val findMonomorphisms : (token * token -> bool) -> map -> mgraph -> mgraph -> map Seq.seq;
+  val findMonomorphisms : (int -> token * token -> bool) -> map -> mgraph -> mgraph -> map Seq.seq;
 
-  val findReificationsUpTo : Type.typeSystem -> token list * token list -> map -> mgraph -> mgraph-> map Seq.seq;
-  val findReifications : Type.typeSystem -> map -> mgraph -> mgraph-> map Seq.seq;
-  val findEmbeddingsUpTo : Type.typeSystem -> token list * token list -> map -> mgraph -> mgraph-> map Seq.seq;
-  val findEmbeddings : Type.typeSystem -> map -> mgraph -> mgraph-> map Seq.seq;
-  val findLooseningsUpTo : Type.typeSystem -> token list * token list -> map -> mgraph -> mgraph -> map Seq.seq;
-  val findLoosenings : Type.typeSystem -> map -> mgraph -> mgraph -> map Seq.seq;
+  val findReificationsUpTo : mTypeSystem -> token list * token list -> map -> mgraph -> mgraph-> map Seq.seq;
+  val findReifications : mTypeSystem -> map -> mgraph -> mgraph-> map Seq.seq;
+  val findEmbeddingsUpTo : mTypeSystem -> token list * token list -> map -> mgraph -> mgraph-> map Seq.seq;
+  val findEmbeddings : mTypeSystem -> map -> mgraph -> mgraph-> map Seq.seq;
+  val findLooseningsUpTo : mTypeSystem -> token list * token list -> map -> mgraph -> mgraph -> map Seq.seq;
+  val findLoosenings : mTypeSystem -> map -> mgraph -> mgraph -> map Seq.seq;
 end
 
 structure MGraph : MGRAPH =
 struct
+  type mTypeSystem = Type.typeSystem list
   type mgraph = Graph.graph list
-  type token = Graph.token
+  open TokenMap
+  infix 6 oo
   type constructor = Graph.constructor
-  type map = Graph.map
 
-  val applyMap = Graph.applyMap  
-  val applyInvMap = Graph.applyInvMap
   fun image f g = List.map (Graph.image f) g
   fun preImage f g = List.map (Graph.preImage f) g
-  val extendMap = Graph.extendMap
 
   exception Mismatch;
 
@@ -428,6 +462,7 @@ struct
 
   val tokensOfGraphFull = List.foldl (fn (gx,tks) => Graph.insertTokens (Graph.tokensOfGraphFull gx) tks) []
   val tokensOfGraphQuick = List.foldl (fn (gx,tks) => Graph.insertTokens (Graph.tokensOfGraphQuick gx) tks) []
+  val tokenNamesOfGraphQuick = List.foldl (fn (gx,tks) => Graph.insertStrings (Graph.tokenNamesOfGraphQuick gx) tks) []
 
   fun mapPairs f [] [] = []
     | mapPairs f (x::X) (y::Y) = f x y :: mapPairs f X Y
@@ -452,16 +487,16 @@ struct
     end
 
  
-  fun foldMaps h f [] [] = Seq.single f
-    | foldMaps h f (x::X) (y::Y) = Seq.maps (fn f' => foldMaps h f' X Y) (h f x y)
-    | foldMaps _ _ _ _ = raise Mismatch
+  fun foldMaps h i f [] [] = Seq.single f
+    | foldMaps h i f (x::X) (y::Y) = Seq.maps (fn f' => foldMaps h (i+1) f' X Y) (h i f x y)
+    | foldMaps _ _ _ _ _ = raise Mismatch
 
-  fun findMonomorphisms p f g1 g2 = foldMaps (Graph.findMonomorphisms p) f g1 g2 
+  fun findMonomorphisms p f g1 g2 = foldMaps (fn i => Graph.findMonomorphisms (p i)) 0 f g1 g2 
 
-  fun findReificationsUpTo T tks f g1 g2 = foldMaps (Graph.findReificationsUpTo T tks) f g1 g2 
-  fun findReifications T f g1 g2 = foldMaps (Graph.findReifications T) f g1 g2 
-  fun findEmbeddingsUpTo T tks f g1 g2 = foldMaps (Graph.findEmbeddingsUpTo T tks) f g1 g2 
-  fun findEmbeddings T f g1 g2 = foldMaps (Graph.findEmbeddings T) f g1 g2 
-  fun findLooseningsUpTo T tks f g1 g2 = foldMaps (Graph.findLooseningsUpTo T tks) f g1 g2 
-  fun findLoosenings T f g1 g2 = foldMaps (Graph.findLoosenings T) f g1 g2 
+  fun findReificationsUpTo T tks f g1 g2 = foldMaps (fn i => Graph.findReificationsUpTo (List.nth(T,i)) tks) 0 f g1 g2 
+  fun findReifications T f g1 g2 = foldMaps (fn i => Graph.findReifications (List.nth(T,i))) 0 f g1 g2 
+  fun findEmbeddingsUpTo T tks f g1 g2 = foldMaps (fn i => Graph.findEmbeddingsUpTo (List.nth(T,i)) tks) 0 f g1 g2 
+  fun findEmbeddings T f g1 g2 = foldMaps (fn i => Graph.findEmbeddings (List.nth(T,i))) 0 f g1 g2 
+  fun findLooseningsUpTo T tks f g1 g2 = foldMaps (fn i => Graph.findLooseningsUpTo (List.nth(T,i)) tks) 0 f g1 g2 
+  fun findLoosenings T f g1 g2 = foldMaps (fn i => Graph.findLoosenings (List.nth(T,i))) 0 f g1 g2 
 end

--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -409,9 +409,9 @@ struct
       end
 
   fun findINMonomorphisms p f [] IN2 = Seq.single f
-    | findINMonomorphisms p f (in1::IN1') IN2 =
+    | findINMonomorphisms p f (in1::IN1) IN2 =
       let 
-        fun monomorphismsPerResult (f',in2) = findINMonomorphisms p f' IN1' (List.remove in2 IN2)
+        fun monomorphismsPerResult (f',in2) = findINMonomorphisms p f' IN1 (List.remove in2 IN2)
         val inputMatches = findInputMatches p f in1 IN2
       in 
         Seq.maps monomorphismsPerResult inputMatches
@@ -459,7 +459,7 @@ struct
     findMonomorphisms (fn (t1,t2) => tokenSpecialises T t2 t1) f g1 g2
 
   fun findEmbeddingsUpTo T (tks1,tks2) f g1 g2 =
-    findMonomorphisms (fn (t1,t2) => tokenSpecialises T t1 t2 orelse tokenInSet t1 tks1 orelse tokenInSet t2 tks2) f g1 g2
+    findMonomorphisms (fn (t1,t2) => tokenSpecialises T t1 t2 orelse (tokenInSet t1 tks1 andalso tokenSpecialises T t2 t1) orelse (tokenInSet t2 tks2 andalso tokenSpecialises T t2 t1)) f g1 g2
   fun findEmbeddings T f g1 g2 =
     findMonomorphisms (fn (t1,t2) => tokenSpecialises T t1 t2) f g1 g2
 
@@ -497,6 +497,8 @@ sig
   val tokensOfGraphFull : mgraph -> token list;
   val tokensOfGraphQuick : mgraph -> token list;
   val tokenNamesOfGraphQuick : mgraph -> string list;
+
+  val normalise : mgraph -> mgraph;
   
   val join : mgraph -> mgraph -> mgraph;
   val remove : mgraph -> mgraph -> mgraph;
@@ -557,6 +559,7 @@ struct
     | mapPairs f (x::X) (y::Y) = f x y :: mapPairs f X Y
     | mapPairs _ _ _ = raise Mismatch
 
+  fun normalise g = map Graph.normalise g
   fun join g g' = mapPairs Graph.join g g'
   fun remove g g' = mapPairs Graph.remove g g'
 

--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -17,14 +17,20 @@ sig
 
   (*
   val normal : graph -> bool;
-  val normalise : graph -> graph;
   *)
+  val makeFromTokens : token list -> graph;
+  val join : graph -> graph -> graph;
+  val normalise : graph -> graph;
 
-  (* findMonomorphisms f p g1 g2 finds every monomorphism m of g1 to g2 that satisfies p(t,m(t)) and is compatible with f *)
-  val findMonomorphisms : map -> (token * token -> bool) -> graph -> graph -> map Seq.seq;
+  (* 
+  findMonomorphisms f p g1 g2 finds every extension of f that is a monomorphism 
+  m from g1 to g2 provided it satisfies p(t,m(t)) for every token t.
+  It assumes the g1 and g2 are in normal form.
+  *)
+  val findMonomorphisms : (token * token -> bool) -> map -> graph -> graph -> map Seq.seq;
 
-  val findReificationsUpTo : Type.typeSystem -> map -> graph -> graph -> token list -> map Seq.seq;
-  val findLooseningsUpTo : Type.typeSystem -> map -> graph -> graph -> token list -> map Seq.seq;
+  val findReificationsUpTo : Type.typeSystem -> token list -> map -> graph -> graph -> map Seq.seq;
+  val findLooseningsUpTo : Type.typeSystem -> token list -> map -> graph -> graph -> map Seq.seq;
 
 end
 
@@ -76,7 +82,27 @@ struct
 
   fun wellFormed CSD g = 
     noDuplicatedTokens g andalso 
-    wellTyped CSD g handle Malformed _ => false 
+    wellTyped CSD g handle Malformed _ => false
+
+  fun insertTIN tin [] = [tin]
+    | insertTIN tin (tin'::g) =
+      if CSpace.sameTokens (#token tin) (#token tin') then
+        {token = #token tin, inputs = (#inputs tin) @ (#inputs tin')} :: g
+      else
+        tin' :: insertTIN tin g
+
+  fun join [] g = g
+    | join (tin::g) g' = insertTIN tin (join g g')
+
+  fun makeFromTokens [] = []
+    | makeFromTokens (t::ts) = insertTIN {token = t, inputs = []} (makeFromTokens ts)
+
+  fun tokensOfTIN tin = #token tin :: List.flatmap #inputTokens (#inputs tin)
+  fun tokensOfGraph g = List.flatmap tokensOfTIN g
+  fun isTotalOver f g = List.all (fn x => isSome (f x)) (tokensOfGraph g)
+
+  fun normalise g = join g (makeFromTokens (tokensOfGraph g))
+
 
   exception Fail
 
@@ -88,76 +114,117 @@ struct
           SOME z => if CSpace.sameTokens x z then fr else raise Fail
         | NONE => (fn t => if CSpace.sameTokens t y then SOME x else fr t))
 
-  fun matchAllPairs f p (x::X) (y::Y) = if p(x,y) then matchAllPairs (addPair (x,y) f) p X Y else raise Fail
-    | matchAllPairs f _ [] [] = f
+  fun matchAllPairs p f (x::X) (y::Y) = if p(x,y) then matchAllPairs p (addPair (x,y) f) X Y else raise Fail
+    | matchAllPairs _ f [] [] = f
     | matchAllPairs _ _ _ _ = raise Fail
 
-  fun findInputMatches f p in1 [] = Seq.empty
-    | findInputMatches f p in1 (in2::IN2') =
+  fun findInputMatches p f in1 [] = Seq.empty
+    | findInputMatches p f in1 (in2::IN2') =
       let 
-        val rest = findInputMatches f p in1 IN2'
+        val rest = findInputMatches p f in1 IN2'
       in
         if #constructor in1 = #constructor in2 then 
-          Seq.cons (matchAllPairs f p (#inputTokens in1) (#inputTokens in2), in2) rest handle Fail => rest
+          Seq.cons (matchAllPairs p f (#inputTokens in1) (#inputTokens in2), in2) rest handle Fail => rest
         else
           rest
       end
 
-  fun findINMonomorphisms f p [] IN2 = Seq.single f
-    | findINMonomorphisms f p (in1::IN1') IN2 =
+  fun findINMonomorphisms p f [] IN2 = Seq.single f
+    | findINMonomorphisms p f (in1::IN1') IN2 =
       let 
-        fun MonomorphismsPerResult (f',in2) = findINMonomorphisms f' p IN1' (List.remove in2 IN2)
-        val inputMatches = findInputMatches f p in1 IN2
+        fun monomorphismsPerResult (f',in2) = findINMonomorphisms p f' IN1' (List.remove in2 IN2)
+        val inputMatches = findInputMatches p f in1 IN2
       in 
-        Seq.maps MonomorphismsPerResult inputMatches
+        Seq.maps monomorphismsPerResult inputMatches
       end
 
-  fun findTINMonomorphisms f p tin1 tin2 =
-    let 
-      val (t1,t2) = (#token tin1,#token tin2)
-    in
-      if p(t1,t2) then 
-        findINMonomorphisms (addPair (t1,t2) f) p (#inputs tin1) (#inputs tin2) handle Fail => Seq.empty
-      else
-        Seq.empty
-    end
+  fun findTINMonomorphisms p f tin1 tin2 =
+      let 
+        val (t1,t2) = (#token tin1,#token tin2)
+      in
+        if p(t1,t2) then 
+          findINMonomorphisms p (addPair (t1,t2) f) (#inputs tin1) (#inputs tin2) handle Fail => Seq.empty
+        else
+          Seq.empty
+      end
 
-  fun findTINMatches f p tin1 [] = Seq.empty
-    | findTINMatches f p tin1 (tin2::g2') =
-        let 
-          val rest = findTINMatches f p tin1 g2'
-        in
-            Seq.cons (findTINMonomorphisms f p tin1 tin2, tin2) rest handle Fail => rest
-        end
+  fun findTINMatches p f tin1 [] = Seq.empty
+    | findTINMatches p f tin1 (tin2::g2') =
+      let 
+        val this = findTINMonomorphisms p f tin1 tin2
+        val rest = findTINMatches p f tin1 g2'
+      in
+        Seq.cons (this, tin2) rest handle Fail => rest
+      end
 
-  fun findMonomorphisms f p [] g2 = Seq.single f
-    | findMonomorphisms f p (tin1::g1') g2 =
-          let 
-            fun MonomorphismsPerResult (F,tin2) = let val g2' = List.remove tin2 g2 in Seq.maps (fn f' => findMonomorphisms f' p g1' g2') F end
-            val TINMatches = findTINMatches f p tin1 g2
-          in 
-            Seq.maps MonomorphismsPerResult TINMatches
-          end
+  fun findMonomorphisms p f [] g2 = Seq.single f
+    | findMonomorphisms p f (tin1::g1') g2 =
+      let 
+        fun monomorphismsPerResult (F,tin2) = 
+            let val g2' = List.remove tin2 g2 
+            in Seq.maps (fn f' => findMonomorphisms p f' g1' g2') F 
+            end
+        val TINMatches = findTINMatches p f tin1 g2
+      in 
+        Seq.maps monomorphismsPerResult TINMatches
+      end
 
   fun tokenSpecialises T t1 t2 = (#subType T) (CSpace.typeOfToken t1,CSpace.typeOfToken t2)
   fun equivalentTokens t1 t2 = CSpace.tokensHaveSameType t1 t2
 
   fun tokenInSet t tks = List.exists (fn x => CSpace.sameTokens t x) tks
 
-  fun findReificationsUpTo T f g1 g2 tks =
-    findMonomorphisms f (fn (t1,t2) => tokenSpecialises T t2 t1 orelse tokenInSet t1 tks) g1 g2
+  fun findReificationsUpTo T tks f g1 g2 =
+    findMonomorphisms (fn (t1,t2) => tokenSpecialises T t2 t1 orelse tokenInSet t1 tks) f g1 g2
 
-  fun findLooseningsUpTo T f g1 g2 tks = Seq.map invertMap (findReificationsUpTo T f g2 g1 tks)
+  fun findLooseningsUpTo T tks f g1 g2 = Seq.map invertMap (findReificationsUpTo T tks f g2 g1)
 
-  fun findLPMonomorphismsUpTo T f g1 g2 tks = 
-    findMonomorphisms f (fn (t1,t2) => equivalentTokens t1 t2 orelse tokenInSet t1 tks) g1 g2
-
-  fun tokensOfTIN tin = #token tin :: List.flatmap #inputTokens (#inputs tin)
-  fun tokensOfGraph g = List.flatmap tokensOfTIN g
-  fun isTotalOver f g = List.all (fn x => isSome (f x)) (tokensOfGraph g)
+  fun findLPMonomorphismsUpTo T tks f g1 g2 = 
+    findMonomorphisms (fn (t1,t2) => equivalentTokens t1 t2 orelse tokenInSet t1 tks) f g1 g2
 
   (* The following actually allows extra constructor vertices to exist on g2 as long as we can inject g1 into g2 and tokens are in bijection *)
-  fun findLPIsomorphismsUpTo T f g1 g2 tks = 
-    Seq.filter (fn (_,f2) => isTotalOver f2 g2) (findLPMonomorphismsUpTo T f g1 g2 tks)
+  fun findLPIsomorphismsUpTo T tks f g1 g2 = 
+    Seq.filter (fn (_,f2) => isTotalOver f2 g2) (findLPMonomorphismsUpTo T tks f g1 g2)
 
+end
+
+signature MGRAPH =
+sig
+  type mgraph = Graph.graph list
+  type token
+  type constructor
+  type map
+
+  val wellTyped : CSpace.conSpecData list -> mgraph -> bool;
+  val wellFormed : CSpace.conSpecData list -> mgraph -> bool;
+  
+  val findMonomorphisms : (token * token -> bool) -> map -> mgraph -> mgraph -> map Seq.seq;
+
+  val findReificationsUpTo : Type.typeSystem -> token list -> map -> mgraph -> mgraph-> map Seq.seq;
+  val findLooseningsUpTo : Type.typeSystem -> token list -> map -> mgraph -> mgraph -> map Seq.seq;
+end
+
+structure MGraph : MGRAPH =
+struct
+  type mgraph = Graph.graph list
+  type token = Graph.token
+  type constructor = Graph.constructor
+  type map = Graph.map
+
+  exception Mismatch;
+
+  fun allPairs f [] [] = true
+    | allPairs f (x::X) (y::Y) = f x y andalso allPairs f X Y
+    | allPairs _ _ _ = raise Mismatch
+
+  fun wellTyped CSDs g = allPairs Graph.wellTyped CSDs g
+  fun wellFormed CSDs g = allPairs Graph.wellFormed CSDs g
+
+  fun foldUpdateMap h f [] [] = Seq.single f
+    | foldUpdateMap h f (x::X) (y::Y) = Seq.maps (fn f' => foldUpdateMap h f' X Y) (h f x y)
+    | foldUpdateMap _ _ _ _ = raise Mismatch
+
+  fun findMonomorphisms p f g1 g2 = foldUpdateMap (Graph.findMonomorphisms p) f g1 g2 
+  fun findReificationsUpTo T tks f g1 g2 = foldUpdateMap (Graph.findReificationsUpTo T tks) f g1 g2 
+  fun findLooseningsUpTo T tks f g1 g2 = foldUpdateMap (Graph.findLooseningsUpTo T tks) f g1 g2 
 end

--- a/src/core/graph.sml
+++ b/src/core/graph.sml
@@ -8,8 +8,10 @@ sig
 
   type TIN; (* token's incoming neighbourhood *)
   type graph;
-  type map;
+  type map; (* these maps are one-to-one relations between tokens. Useful as we use monomorphisms a lot. *)
 
+  val emptyMap : map;
+  val identityMap : map;
   val addPair : token * token -> map -> map;
   val updatePair : token * token -> map -> map;
   
@@ -77,6 +79,8 @@ struct
   type graph = TIN set
   type map = (token -> token option) * (token -> token option)
 
+  val emptyMap = (fn _ => NONE, fn _ => NONE)
+  val identityMap = (fn t => SOME t, fn t => SOME t)
 
   exception Malformed of string;
 
@@ -153,7 +157,7 @@ struct
             [] => g 
           | inps => {token = #token tin, inputs = inps} :: g
       else
-        tin' :: insertTIN tin g
+        tin' :: removeTIN tin g
 
   fun join [] g = g
     | join (tin::g) g' = insertTIN tin (join g g')
@@ -173,6 +177,7 @@ struct
 
   fun isTotalOver f g = List.all (fn x => isSome (f x)) (tokensOfGraphQuick g)
 
+  (* removes g from g'. If there is a configuration in g' that is not in g then the whole *)
   fun remove g g' =
     let 
       fun rem [] g = g

--- a/src/core/scaffolding.sml
+++ b/src/core/scaffolding.sml
@@ -1,13 +1,30 @@
-import "core.pattern";
-import "core.graph";
+import "core.sequent";
+import "core.interCSpace";
+import "transfer.search";
 
-signature SCAFOLDING =
+signature SCAFFOLDING =
 sig 
   val graphOfOldConstruction : Pattern.construction -> Graph.graph
   val oldConstructionsOfGraph : CSpace.conSpecData -> Graph.graph -> Pattern.construction list
+  val schemaOfOldTransferSchema : InterCSpace.tSchemaData -> Sequent.schemaData
+  val applyTransferSchemas : MSpace.mTypeSystem -> Sequent.schemaData Seq.seq -> Sequent.state -> Sequent.state Seq.seq
+  val transfer : int option * int option * int option
+                  -> bool
+                  -> bool
+                  -> bool
+                  -> Sequent.mTypeSystem
+                  -> Sequent.schemaData Seq.seq
+                  -> Sequent.state
+                  -> Sequent.state Seq.seq
+  val initState : CSpace.conSpecData -> (* Source Constructor Specification *)
+                  CSpace.conSpecData -> (* Target Constructor Specification *)
+                  CSpace.conSpecData -> (* Inter-space Constructor Specification *)
+                  Construction.construction -> (* The construction to transform *)
+                  Construction.construction -> (* The goal to satisfy *)
+                  Sequent.state
 end
 
-structure Scaffolding : SCAFOLDING =
+structure Scaffolding : SCAFFOLDING =
 struct
 
   fun graphOfOldConstruction ct =
@@ -42,7 +59,7 @@ struct
                 (List.exists (fn x => x) X, Pattern.TCPair (tc,CH)))
         | attachDownwards {token,inputs = []} (Pattern.Reference t) = (CSpace.sameTokens token t,Pattern.Reference t)
         | attachDownwards tin (Pattern.Reference t) = (false,Pattern.Reference t)
-        | attachDownwards _ _ = raise Match
+        | attachDownwards _ _ = (print "can't attach downwards";raise Match)
 
       fun makeFromTokenListAndAttach [] ct = (false, [])
         | makeFromTokenListAndAttach (tk::tks) ct = 
@@ -67,6 +84,62 @@ struct
       fun ocog [] cts = cts
         | ocog (tin::g') cts = ocog g' (ocotin tin cts)
     in ocog (Graph.expand g) []
+    end
+
+  fun schemaOfOldTransferSchema tSchemaData =
+    let
+      val tschema = #tSchema tSchemaData
+      val s = graphOfOldConstruction (#source tschema)
+      val t = graphOfOldConstruction (#target tschema)
+      val a = Graph.factorise (List.flatmap graphOfOldConstruction (#antecedent tschema))
+      val c = graphOfOldConstruction (#consequent tschema)
+    in 
+      {schema = ([s,t,a],[Graph.empty,Graph.empty,c]), strength = #strength tSchemaData}
+    end
+
+  fun applyTransferSchemas T SC st = 
+    Sequent.applyBackwardAllToState T (fn i => i = 1) SC st 
+
+  
+  fun compare (st1,st2) = 
+    let 
+      val (A1,C1) = #sequent st1
+      val (A2,C2) = #sequent st2
+    in
+      case (MGraph.contained C1 A1, MGraph.contained C2 A2) of
+          (true,false) => LESS
+        | (false,true) => GREATER
+        | _ => Real.compare (#score st2, #score st1)
+    end
+
+  fun ignore maxNumGoals maxNumResults maxCompSize unistructured (st,L) =
+    let
+      val (A',C') = #sequent st
+    in 
+      (Graph.numberOfConstructors (List.last C') > maxNumGoals orelse 
+      length L > maxNumResults orelse
+      Graph.size (List.nth(C',1)) > maxCompSize) 
+    end
+
+  fun transfer (goalLimit,compositionLimit,searchLimit) eager iterative unistructured T SC state =
+    let
+      val maxNumGoals = case goalLimit of SOME x => x | NONE => 5
+      val maxCompSize = case compositionLimit of SOME x => x | NONE => 100
+      val maxNumResults = case searchLimit of SOME x => x | NONE => 100
+      val ignT = ignore maxNumGoals maxNumResults maxCompSize unistructured
+      val stop = if eager then (fn x => case #sequent x of (A',C') => MGraph.contained C' A') else (fn _ => false)
+    in
+      Search.bestFirstAll (applyTransferSchemas T SC) compare ignT (fn _ => false) stop state 
+    end
+  
+  fun initState sCSD tCSD iCSD ct goal =
+    let val tTS = #typeSystem (#typeSystemData tCSD)
+        val targetTokens = FiniteSet.filter
+                               (fn x => Set.elementOf (CSpace.typeOfToken x) (#Ty tTS) andalso
+                                        not (FiniteSet.elementOf x (Construction.tokensOfConstruction ct)))
+                               (Construction.leavesOfConstruction goal);
+        val sequent = ([graphOfOldConstruction ct, Graph.empty, Graph.empty], [Graph.empty, Graph.makeFromTokens targetTokens, graphOfOldConstruction goal])
+    in {sequent = sequent, discharged = [Graph.empty,Graph.empty,Graph.empty], tokenNamesUsed = [], score = 0.0}
     end
 
 end

--- a/src/core/scaffolding.sml
+++ b/src/core/scaffolding.sml
@@ -1,0 +1,72 @@
+import "core.pattern";
+import "core.graph";
+
+signature SCAFOLDING =
+sig 
+  val graphOfOldConstruction : Pattern.construction -> Graph.graph
+  val oldConstructionsOfGraph : CSpace.conSpecData -> Graph.graph -> Pattern.construction list
+end
+
+structure Scaffolding : SCAFOLDING =
+struct
+
+  fun graphOfOldConstruction ct =
+    let
+      fun gooc (Pattern.Source t) = [{token = t, inputs = []}]
+        | gooc (Pattern.Reference t) = [{token = t, inputs = []}]
+        | gooc (Pattern.TCPair (tc,ch)) = {token = #token tc, inputs = [{constructor = CSpace.nameOfConstructor (#constructor tc), inputTokens = map Pattern.constructOf ch}]} :: List.flatmap gooc ch
+    in Graph.factorise (gooc ct)
+    end
+
+  fun unzip [] = ([],[])
+    | unzip ((x,y)::L) = case unzip L of (Lx,Ly) => (x::Lx,y::Ly)
+
+  fun oldConstructionsOfGraph CS g =
+    let
+      fun getConstructor cn = case CSpace.findConstructorWithName cn CS of SOME c => c | NONE => (print ("constructor " ^cn ^ " not found"); raise Option)
+      fun tokensMatchConstructs [] [] = true
+        | tokensMatchConstructs (tk::tks) (ct::cts) = CSpace.sameTokens tk (Pattern.constructOf ct) andalso tokensMatchConstructs tks cts
+        | tokensMatchConstructs _ _ = false
+      fun attachDownwards {token,inputs = []} (Pattern.Source t) = (CSpace.sameTokens token t, Pattern.Source t)
+        | attachDownwards {token,inputs = [{constructor,inputTokens}]} (Pattern.Source t) = 
+            if CSpace.sameTokens token t then 
+              (true, Pattern.TCPair ({token = token, constructor = getConstructor constructor}, map Pattern.Source inputTokens))
+            else 
+              (false, Pattern.Source t)
+        | attachDownwards {token,inputs = []} (Pattern.TCPair (tc,ch)) = (CSpace.sameTokens token (#token tc), Pattern.TCPair (tc,ch))
+        | attachDownwards (tin as {token,inputs = [{constructor,inputTokens}]}) (Pattern.TCPair (tc,ch)) = 
+            if CSpace.sameTokens token (#token tc) andalso constructor = CSpace.nameOfConstructor (#constructor tc) andalso tokensMatchConstructs inputTokens ch then
+              (true,Pattern.TCPair (tc,ch))
+            else
+              (case unzip (map (attachDownwards tin) ch) of (X,CH) =>
+                (List.exists (fn x => x) X, Pattern.TCPair (tc,CH)))
+        | attachDownwards {token,inputs = []} (Pattern.Reference t) = (CSpace.sameTokens token t,Pattern.Reference t)
+        | attachDownwards tin (Pattern.Reference t) = (false,Pattern.Reference t)
+        | attachDownwards _ _ = raise Match
+
+      fun makeFromTokenListAndAttach [] ct = (false, [])
+        | makeFromTokenListAndAttach (tk::tks) ct = 
+            if CSpace.sameTokens tk (Pattern.constructOf ct) then 
+              (true,ct :: map Pattern.Source tks)
+            else 
+              let val (x,cts) = makeFromTokenListAndAttach tks ct 
+              in (x, Pattern.Source tk :: cts) 
+              end
+      fun attach (tin as {token,inputs = []}) ct = attachDownwards tin ct
+        | attach (tin as {token,inputs = [{constructor,inputTokens}]}) ct = 
+          let val (x,ch) = makeFromTokenListAndAttach inputTokens ct 
+          in if x then (x,Pattern.TCPair ({token = token, constructor = getConstructor constructor}, ch)) else attachDownwards tin ct
+          end
+      fun ocotinSingle ({token,inputs = []}) = Pattern.Source token
+        | ocotinSingle ({token,inputs = [{constructor,inputTokens}]}) = Pattern.TCPair ({token = token, constructor = getConstructor constructor}, map Pattern.Source inputTokens)
+      fun ocotin tin [] = [ocotinSingle tin]
+        | ocotin tin (ct::cts) = 
+          let val (x,ct') = attach tin ct 
+          in if x then (ct'::cts) else ct :: ocotin tin cts
+          end
+      fun ocog [] cts = cts
+        | ocog (tin::g') cts = ocog g' (ocotin tin cts)
+    in ocog (Graph.expand g) []
+    end
+
+end

--- a/src/core/sequent.sml
+++ b/src/core/sequent.sml
@@ -66,7 +66,7 @@ struct
             in Seq.map mapWithDelta (MGraph.findReifications T f sA A')
             end
         in 
-          Seq.maps findPerSubgraph (MGraph.findSubgraphs A)
+          Seq.maps findPerSubgraph (MGraph.subgraphs A)
         end
     in
       Seq.maps findDeltasForReification consequentMaps 

--- a/src/core/sequent.sml
+++ b/src/core/sequent.sml
@@ -43,10 +43,10 @@ struct
 
 
   (* 
-    findDeltasForReification finds values d such that g can be reified into g' \cup d.
+    provided that C can be embedded in C', refineForBackwardApp finds value d such that A can be reified into A' \cup d.
     There are infinitely many, so here we only find minimal ones.
-    The idea is: for every subgraph, s, of g, find a reification of s into g'.
-    Then take the complement of s in g and create a copy, d, of it so that g reifies into g' cup d. 
+    The idea is: for each subgraph, sA, of A, find a reification of sA into A'.
+    Then take the complement of sA in A and create a copy, d, of it so that A reifies into A' cup d. 
   *)
   fun refineForBackwardApp T (A,C) (A',C') =
     let

--- a/src/core/sequent.sml
+++ b/src/core/sequent.sml
@@ -1,0 +1,35 @@
+import "core.graph";
+
+signature SEQUENT =
+sig
+  type mgraph
+  type map
+  type sequent = mgraph * mgraph
+
+  (* 
+    refineForBackwardApp takes a pair of sequents <a1,...,an ||- c1,...,cn> and 
+    <a1',...,an' ||- c1',...,cn'> and finds refinement maps of <a1,...,an ||- c1,...,cn>. 
+    For each refinement map, r, it returns a pair (r,(d1,...,dn)) where (d1,...,dn) is a
+    multi-space graph of deltas such that <a1' \cup d1, ..., an' \cup dn ||- c1',...,cn'>
+    is a refinement of <a1,...,an ||- c1,...,cn>. Importantly, this means that 
+    <a1',...,an' ||- d1,...,dn> is an application of <a1,...,an ||- c1,...,cn> to
+    <a1',...,an' ||- c1',...,cn'>.
+  *)
+  val refineForBackwardApp : sequent -> sequent -> (map * mgraph) Seq.seq
+
+  val applyBackward : sequent -> sequent -> sequent Seq.seq
+
+  (* 
+    refineForForwardApp takes a pair of sequents <a1,...,an ||- c1,...,cn> and 
+    <a1',...,an' ||- c1',...,cn'> and finds refinement maps of <a1,...,an ||- c1,...,cn>. 
+    For each refinement map, r, it returns a pair (r,(d1,...,dn)) where (d1,...,dn) is a
+    multi-space graph of deltas such that <a1',...,an' ||- d1,...,dn> is a refinement of
+    <a1,...,an ||- c1,...,cn>. Importantly, this means that 
+    <a1' \cup d1, ..., an' \cup dn ||- c1',...,cn'> is an application of 
+    <a1,...,an ||- c1,...,cn> to <a1',...,an' ||- c1',...,cn'>.
+  *)
+  val refineForForwardApp : sequent -> sequent -> (map * mgraph) Seq.seq
+
+  val applyForward : sequent -> sequent -> sequent Seq.seq
+
+end

--- a/src/core/sequent.sml
+++ b/src/core/sequent.sml
@@ -33,3 +33,12 @@ sig
   val applyForward : sequent -> sequent -> sequent Seq.seq
 
 end
+
+
+structure Sequent : SEQUENT =
+struct
+  type mgraph = MGraph.mgraph
+  type map = MGraph.map
+  type sequent = mgraph * mgraph
+  
+end

--- a/src/core/sequent.sml
+++ b/src/core/sequent.sml
@@ -12,10 +12,10 @@ sig
     findDeltasForBackwardApp takes a pair of sequents <a1,...,an ||- c1,...,cn> and 
     <a1',...,an' ||- c1',...,cn'> and finds refinement maps of <a1,...,an ||- c1,...,cn>. 
     For each refinement map, r, it returns a pair (r,(d1,...,dn)) where (d1,...,dn) is a
-    multi-space graph of deltas such that <a1' \cup d1, ..., an' \cup dn ||- c1',...,cn'>
-    is a refinement of <a1,...,an ||- c1,...,cn>. Importantly, this means that 
-    <a1',...,an' ||- d1,...,dn> is an application of <a1,...,an ||- c1,...,cn> to
-    <a1',...,an' ||- c1',...,cn'>.
+    multi-space graph of deltas such that <a1' \cup d1, ..., an' \cup dn ||- c1'',...,cn''>
+    is a refinement of <a1,...,an ||- c1,...,cn> and (c1'',...,cn'') is a specialisation of 
+    (c1',...,cn'). Importantly, this means that <a1',...,an' ||- d1,...,dn> is an 
+    application of <a1,...,an ||- c1,...,cn> to <a1',...,an' ||- c1',...,cn'>.
   *)
   val findDeltasForBackwardApp : mTypeSystem -> (int -> bool) -> string list -> sequent -> sequent -> (map * map * mgraph) Seq.seq
 
@@ -36,8 +36,10 @@ sig
 
   val applyForward : mTypeSystem -> sequent -> sequent -> sequent Seq.seq
 *)
+
   type state = {sequent : sequent, discharged : mgraph, tokenNamesUsed : string list}
   val applyBackwardToState : mTypeSystem -> (int -> bool) -> sequent -> state -> state Seq.seq
+  val applyBackwardAllToState : mTypeSystem -> (int -> bool) -> sequent Seq.seq -> state -> state Seq.seq
 end
 
 
@@ -53,7 +55,10 @@ struct
 
   (* 
     The assumption for findDeltasForBackwardApp is that (A,C) is a schema and (A',C') is a sequent.
-    It aims to find a d such that (A,C) can be refined into (A' \cup d, C'). 
+    It aims to find a d such that (A,C) can be refined into (A' \cup d, C'') where C'' is a specialisation of C'.
+    findDeltasForBackwardApp returns (f,gf,d) where f is the refinement map of (A,C) to (A' \cup d, C''), and gf maps C' to C''.
+    That's slightly stronger than the Transfer paper's version of backward application, but still ensures that
+    if (A',d) is a schema then (A',C') is a schema.
     The first thing is to check that C can be embedded in C' (a more complete version would find loosenings rather than embeddings, 
     but practically this may add too many useless cases).
     If so, then we proceed to find d such that A can be reified into A' \cup d.
@@ -61,43 +66,46 @@ struct
     The idea is: for each subgraph, sA, of A, find a reification of sA into A'.
     Then take the complement of sA in A and create a copy, d, disjoint from A', of it so that A reifies into A' cup d.
     I is a list of integers that indicates the dimensions on which we DO NOT want non-trivial deltas, i.e., where (#i sA) = (#i A).
-    It returns (f,gf,d) where f maps 
+    
   *)
   fun findDeltasForBackwardApp T I tns (A,C) (A',C') =
     let
-      val consequentMaps = 
+      val consequentEmbeddings = 
         MGraph.findEmbeddingsUpTo T (MGraph.tokensOfGraphQuick A,[]) emptyMap C C'
 
       val tokensOfAC = Graph.insertStrings (MGraph.tokenNamesOfGraphQuick A) (MGraph.tokenNamesOfGraphQuick C)
       val tokensOfAC' = Graph.insertStrings (Graph.insertStrings (MGraph.tokenNamesOfGraphQuick A') (MGraph.tokenNamesOfGraphQuick C')) tns
 
-      fun findDeltasPerConsequentMap f = 
+      fun findDeltasPerConsequentEmbedding consequentEmbedding = 
         let 
-          val extendedInverseConsequentMap = #1 (extendDomain (invertMap f) (MGraph.tokensOfGraphQuick C') tokensOfAC)
-          val extendedC = MGraph.image extendedInverseConsequentMap C'
-          val restrictedConsequentMap = restrictDomain (invertMap extendedInverseConsequentMap) (MGraph.tokensOfGraphQuick A)
-          val (extendedConsequentMap,newTokensUsed') = extendDomain restrictedConsequentMap (MGraph.tokensOfGraphQuick extendedC) tokensOfAC'
-          val consequentDelta = MGraph.image extendedConsequentMap (MGraph.remove C extendedC)
-          val goalMap = extendedConsequentMap oo extendedInverseConsequentMap
+          val extendedInverseConsequentEmbedding = #1 (extendDomain (invertMap consequentEmbedding) (MGraph.tokensOfGraphQuick C') tokensOfAC)
+          val extendedC = MGraph.image extendedInverseConsequentEmbedding C' (* extension of C that mimics the structure of C' *)
+          val restrictedConsequentEmbedding = restrictDomain (invertMap extendedInverseConsequentEmbedding) (MGraph.tokensOfGraphQuick A)
+          (* restricting the domain of consequentEmbedding *)
+          val (extendedConsequentEmbedding,newTokensUsed') = extendDomain restrictedConsequentEmbedding (MGraph.tokensOfGraphQuick extendedC) tokensOfAC'
+          val consequentDelta = MGraph.image extendedConsequentEmbedding (MGraph.remove C extendedC)
+          val goalMap = extendedConsequentEmbedding oo extendedInverseConsequentEmbedding
 
-          fun findPerSubgraph sA = 
+          val subgraphsOfA = MGraph.subgraphsRestricted I A
+          fun findPerSubgraphOfA subgraphOfA = 
             let 
-              fun findPerReificationOfsA f' = 
+              val antecedentReifications = MGraph.findReifications T extendedConsequentEmbedding subgraphOfA A'
+              fun findPerReificationOfSubgraphOfA f' = 
                 let 
-                  val complementOfsA = MGraph.remove sA A
-                  val extendedMap = #1 (extendDomain f' (MGraph.tokensOfGraphQuick complementOfsA) (tokensOfAC' @ newTokensUsed')) (* extend domain of f' : sA -> A' from sA to A avoiding clashing with A' union C' *)
-                  val antecedentDelta = MGraph.image extendedMap complementOfsA
+                  val complementOfSubgraphOfA = MGraph.remove subgraphOfA A
+                  val extendedMap = #1 (extendDomain f' (MGraph.tokensOfGraphQuick complementOfSubgraphOfA) (tokensOfAC' @ newTokensUsed')) (* extend domain of f' : subgraphOfA -> A' from subgraphOfA to A avoiding clashing with A' union C' *)
+                  val antecedentDelta = MGraph.image extendedMap complementOfSubgraphOfA
                 in 
                   (extendedMap, goalMap, MGraph.join consequentDelta antecedentDelta)
                 end
             in 
-              Seq.map findPerReificationOfsA (MGraph.findReifications T extendedConsequentMap sA A')
+              Seq.map findPerReificationOfSubgraphOfA antecedentReifications
             end
         in 
-          Seq.maps findPerSubgraph (MGraph.subgraphsRestricted I A)
+          Seq.maps findPerSubgraphOfA subgraphsOfA
         end
     in
-      Seq.maps findDeltasPerConsequentMap consequentMaps 
+      Seq.maps findDeltasPerConsequentEmbedding consequentEmbeddings 
     end
 
   fun applyBackwardFree T (A,C) (A',C') = Seq.map (fn x => (A', #3 x)) (findDeltasForBackwardApp T (fn _ => false) [] (A,C) (A',C'))

--- a/src/core/sequent.sml
+++ b/src/core/sequent.sml
@@ -50,7 +50,8 @@ struct
   (* 
     The assumption for findDeltasForBackwardApp is that (A,C) is a schema and (A',C') is a sequent.
     It aims to find a d such that (A,C) can be refined into (A' \cup d, C'). 
-    The first thing is to check that C can be embedded in C'.
+    The first thing is to check that C can be embedded in C' (a more complete version would find loosenings rather than embeddings, 
+    but practically this may add too many useless cases).
     If so, then we proceed to find d such that A can be reified into A' \cup d.
     There are infinitely many, so we restrict it to find 'minimal' ones.
     The idea is: for each subgraph, sA, of A, find a reification of sA into A'.


### PR DESCRIPTION
The graph branch generalises the foundations of Oruga from the old encoding of constructions, decompositions and top-down application of transfer schemas to  one that includes general structure graphs, multi-space systems, sequents, schemas and general schema application used for both inference and structure transfer.